### PR TITLE
add a readme for the example app

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -1,0 +1,10 @@
+# Example App Setup
+
+Want to try our react-native-graph right away? Check out the example app.
+
+## Steps to get the example app working on iOS
+
+1. `git clone` this repo
+2. `yarn install` in both the `/example` folder and in the top level.
+3. In the `example` folder, `npx pod-install` or `cd ios && pod install` to install iOS dependencies
+4. In the `example` folder, run `yarn ios`


### PR DESCRIPTION
I ran into an issue getting the iOS app to work.  (`Error: Unable to resolve module @babel/runtime/helpers/interopRequireDefault`)

I looked at the babel config of the example app, and saw it was looking at the package.json at the root of the project (line 2: `const pak = require('../package.json')`

That might be the root cause of the issue with the iOS app not working unless you also `yarn install` in the root of the project. This seems like a hacky workaround, and should probably instead make the `example` folder independent of the root project, but...this is also a fast way to get people up and going with the example app until then.