### PR TITLE
Improve behavior for animated graph with gesture

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,7 +126,8 @@
     "singleQuote": true,
     "tabWidth": 2,
     "trailingComma": "es5",
-    "useTabs": false
+    "useTabs": false,
+    "semi": false
   },
   "react-native-builder-bob": {
     "source": "src",

--- a/src/LineGraphProps.ts
+++ b/src/LineGraphProps.ts
@@ -69,11 +69,6 @@ export type AnimatedLineGraphProps = BaseLineGraphProps & {
   gestureHoldDuration?: number
 
   /**
-   * Initial index shown on the graph
-   */
-  initialIndex?: number
-
-  /**
    * Wether to reset or not the circle position when releasing the gesture
    */
   resetPositionOnRelease?: boolean

--- a/src/LineGraphProps.ts
+++ b/src/LineGraphProps.ts
@@ -62,6 +62,21 @@ export type AnimatedLineGraphProps = BaseLineGraphProps & {
    * The element that gets rendered below the Graph (usually the "min" point/value of the Graph)
    */
   BottomAxisLabel?: () => React.ReactElement | null
+
+  /**
+   * Hold duration for the graph gesture
+   */
+  gestureHoldDuration?: number
+
+  /**
+   * Initial index shown on the graph
+   */
+  initialIndex?: number
+
+  /**
+   * Wether to reset or not the circle position when releasing the gesture
+   */
+  resetPositionOnRelease?: boolean
 }
 
 export type LineGraphProps =


### PR DESCRIPTION
Animated graph with gestures enabled had some improvements in my opinion.

This PR adds the following:

- Allows to highlight the graph partially thanks to an `initialIndex` prop. This will basically give an initial position to the circle. The old behavior was not really appropriate: the whole graph had a translucent color. With this prop, this gives the possibility to highlight the whole graph.
- Add the possibility to pass a custom duration for the gesture long press gesture
- Currently, when releasing the gesture, the circle goes back to the end of the graph. The PR introduces a `resetPositionOnRelease` prop. Passing `true` as a value will keep the old behavior, while passing `false` will keep the circle at the last position where the gesture was released.