### PR TITLE
Feat: Add horizontal- and verticalPadding prop to AnimatedLineGraph component 

### DIFF
--- a/src/AnimatedLineGraph.tsx
+++ b/src/AnimatedLineGraph.tsx
@@ -41,6 +41,7 @@ export function AnimatedLineGraph({
   TopAxisLabel,
   BottomAxisLabel,
   selectionDotShadowColor,
+  axisLabelContainerStyle,
   ...props
 }: AnimatedLineGraphProps): React.ReactElement {
   const [width, setWidth] = useState(0)
@@ -230,7 +231,13 @@ export function AnimatedLineGraph({
   return (
     <View {...props}>
       <GestureDetector gesture={enablePanGesture ? gesture : undefined}>
-        <ReanimatedView style={styles.container}>
+        <ReanimatedView
+          style={[
+            styles.container,
+            styles.axisLabelContainer,
+            axisLabelContainerStyle,
+          ]}
+        >
           {/* Top Label (max price) */}
           {TopAxisLabel != null && (
             <View style={styles.axisRow}>
@@ -298,6 +305,9 @@ const styles = StyleSheet.create({
   },
   container: {
     flex: 1,
+  },
+  axisLabelContainer: {
+    paddingVertical: 20,
   },
   axisRow: {
     height: 17,

--- a/src/AnimatedLineGraph.tsx
+++ b/src/AnimatedLineGraph.tsx
@@ -38,16 +38,26 @@ export function AnimatedLineGraph({
   onPointSelected,
   onGestureStart,
   onGestureEnd,
+  horizontalPadding = 30,
+  verticalPadding = 30,
   TopAxisLabel,
   BottomAxisLabel,
   selectionDotShadowColor,
-  axisLabelContainerStyle,
   ...props
 }: AnimatedLineGraphProps): React.ReactElement {
   const [width, setWidth] = useState(0)
   const [height, setHeight] = useState(0)
   const interpolateProgress = useValue(0)
-  const graphPadding = lineThickness
+
+  const { gesture, isActive, x } = useHoldOrPanGesture({ holdDuration: 300 })
+  const circleX = useValue(0)
+  const circleY = useValue(0)
+  const pathEnd = useValue(0)
+  const circleRadius = useValue(0)
+  const circleStrokeRadius = useDerivedValue(
+    () => circleRadius.current * 6,
+    [circleRadius]
+  )
 
   const onLayout = useCallback(
     ({ nativeEvent: { layout } }: LayoutChangeEvent) => {
@@ -84,7 +94,8 @@ export function AnimatedLineGraph({
 
     const path = createGraphPath({
       points: points,
-      graphPadding: graphPadding,
+      horizontalPadding: lineThickness + horizontalPadding,
+      verticalPadding: lineThickness + verticalPadding,
       canvasHeight: height,
       canvasWidth: width,
     })
@@ -118,12 +129,15 @@ export function AnimatedLineGraph({
       }
     )
   }, [
-    graphPadding,
+    circleStrokeRadius,
     height,
+    horizontalPadding,
     interpolateProgress,
+    lineThickness,
     paths,
     points,
     straightLine,
+    verticalPadding,
     width,
   ])
 
@@ -159,16 +173,6 @@ export function AnimatedLineGraph({
     [interpolateProgress]
   )
 
-  const { gesture, isActive, x } = useHoldOrPanGesture({ holdDuration: 300 })
-  const circleX = useValue(0)
-  const circleY = useValue(0)
-  const pathEnd = useValue(0)
-  const circleRadius = useValue(0)
-  const circleStrokeRadius = useDerivedValue(
-    () => circleRadius.current * 6,
-    [circleRadius]
-  )
-
   const setFingerX = useCallback(
     (fingerX: number) => {
       const y = getYForX(commands.current, fingerX)
@@ -201,6 +205,7 @@ export function AnimatedLineGraph({
     },
     [circleRadius, onGestureEnd, onGestureStart, pathEnd]
   )
+
   useAnimatedReaction(
     () => x.value,
     (fingerX) => {
@@ -217,6 +222,7 @@ export function AnimatedLineGraph({
     },
     [isActive, setIsActive]
   )
+
   const positions = useDerivedValue(
     () => [
       0,
@@ -231,13 +237,7 @@ export function AnimatedLineGraph({
   return (
     <View {...props}>
       <GestureDetector gesture={enablePanGesture ? gesture : undefined}>
-        <ReanimatedView
-          style={[
-            styles.container,
-            styles.axisLabelContainer,
-            axisLabelContainerStyle,
-          ]}
-        >
+        <ReanimatedView style={[styles.container, styles.axisLabelContainer]}>
           {/* Top Label (max price) */}
           {TopAxisLabel != null && (
             <View style={styles.axisRow}>

--- a/src/CreateGraphPath.ts
+++ b/src/CreateGraphPath.ts
@@ -7,9 +7,13 @@ interface GraphPathConfig {
    */
   points: GraphPoint[]
   /**
-   * Optional Padding (top, left, bottom, right) for the Graph to correctly round the Path.
+   * Optional Padding (left, right) for the Graph to correctly round the Path.
    */
-  graphPadding: number
+  horizontalPadding: number
+  /**
+   * Optional Padding (top, bottom) for the Graph to correctly round the Path.
+   */
+  verticalPadding: number
   /**
    * Height of the Canvas (Measured with onLayout)
    */
@@ -25,12 +29,11 @@ const PIXEL_RATIO = 2
 
 export function createGraphPath({
   points: graphData,
-  graphPadding,
+  horizontalPadding,
+  verticalPadding,
   canvasHeight: height,
   canvasWidth: width,
 }: GraphPathConfig): SkPath {
-  const innerHeight = height - 2 * graphPadding
-
   const maxValue = graphData.reduce(
     (prev, curr) => (curr.value > prev ? curr.value : prev),
     Number.MIN_SAFE_INTEGER
@@ -46,11 +49,13 @@ export function createGraphPath({
     const index = Math.floor((pixel / width) * graphData.length)
     const value = graphData[index]?.value ?? minValue
 
-    const x = (pixel / width) * (width - 2 * graphPadding) + graphPadding
+    const x =
+      (pixel / width) * (width - 2 * horizontalPadding) + horizontalPadding
     const y =
       height -
-      ((value - minValue) / (maxValue - minValue)) * innerHeight -
-      graphPadding
+      (((value - minValue) / (maxValue - minValue)) *
+        (height - 2 * verticalPadding) +
+        verticalPadding)
 
     points.push({ x: x, y: y })
   }

--- a/src/LineGraphProps.ts
+++ b/src/LineGraphProps.ts
@@ -1,5 +1,5 @@
 import type React from 'react'
-import type { ViewProps } from 'react-native'
+import type { StyleProp, ViewStyle, ViewProps } from 'react-native'
 
 export interface GraphPoint {
   value: number
@@ -62,6 +62,10 @@ export type AnimatedLineGraphProps = BaseLineGraphProps & {
    * The element that gets rendered below the Graph (usually the "min" point/value of the Graph)
    */
   BottomAxisLabel?: () => React.ReactElement | null
+  /**
+   * Style to be applied to the container wrapping the graph and the AxisLabels (Top/Bottom)
+   */
+  axisLabelContainerStyle?: StyleProp<ViewStyle>
 }
 
 export type LineGraphProps =

--- a/src/LineGraphProps.ts
+++ b/src/LineGraphProps.ts
@@ -1,5 +1,5 @@
 import type React from 'react'
-import type { StyleProp, ViewStyle, ViewProps } from 'react-native'
+import type { ViewProps } from 'react-native'
 
 export interface GraphPoint {
   value: number
@@ -40,6 +40,14 @@ export type AnimatedLineGraphProps = BaseLineGraphProps & {
    * The color of the selection dot when the user is panning the graph.
    */
   selectionDotShadowColor?: string
+  /**
+   * Horizontal padding applied to graph, so the selectionDot doesn't get cut off horizontally
+   */
+  horizontalPadding?: number
+  /**
+   * Vertical padding applied to graph, so the selectionDot doesn't get cut off vertically
+   */
+  verticalPadding?: number
 
   /**
    * Called for each point while the user is scrubbing/panning through the graph
@@ -62,10 +70,6 @@ export type AnimatedLineGraphProps = BaseLineGraphProps & {
    * The element that gets rendered below the Graph (usually the "min" point/value of the Graph)
    */
   BottomAxisLabel?: () => React.ReactElement | null
-  /**
-   * Style to be applied to the container wrapping the graph and the AxisLabels (Top/Bottom)
-   */
-  axisLabelContainerStyle?: StyleProp<ViewStyle>
 }
 
 export type LineGraphProps =

--- a/src/LineGraphProps.ts
+++ b/src/LineGraphProps.ts
@@ -41,11 +41,11 @@ export type AnimatedLineGraphProps = BaseLineGraphProps & {
    */
   selectionDotShadowColor?: string
   /**
-   * Horizontal padding applied to graph, so the selectionDot doesn't get cut off horizontally
+   * Horizontal padding applied to graph, so the selection dot doesn't get cut off horizontally
    */
   horizontalPadding?: number
   /**
-   * Vertical padding applied to graph, so the selectionDot doesn't get cut off vertically
+   * Vertical padding applied to graph, so the selection dot doesn't get cut off vertically
    */
   verticalPadding?: number
 

--- a/src/StaticLineGraph.tsx
+++ b/src/StaticLineGraph.tsx
@@ -15,7 +15,6 @@ export function StaticLineGraph({
 }: StaticLineGraphProps): React.ReactElement {
   const [width, setWidth] = useState(0)
   const [height, setHeight] = useState(0)
-  const graphPadding = lineThickness
 
   const onLayout = useCallback(
     ({ nativeEvent: { layout } }: LayoutChangeEvent) => {
@@ -31,9 +30,10 @@ export function StaticLineGraph({
         points: points,
         canvasHeight: height,
         canvasWidth: width,
-        graphPadding: graphPadding,
+        horizontalPadding: lineThickness,
+        verticalPadding: lineThickness,
       }),
-    [graphPadding, height, points, width]
+    [height, lineThickness, points, width]
   )
 
   const gradientColors = useMemo(


### PR DESCRIPTION
Add `horizontalPadding` and `verticalPadding` props to `AnimatedLineGraph`, so the active dot/circle doesn't get cut off when using the pan gesture.