### PR TITLE
fix: fingerX using last value instead of current

### DIFF
--- a/src/AnimatedLineGraph.tsx
+++ b/src/AnimatedLineGraph.tsx
@@ -203,7 +203,7 @@ export function AnimatedLineGraph({
   useAnimatedReaction(
     () => x.value,
     (fingerX) => {
-      if (isActive.value) {
+      if (isActive.value || fingerX) {
         runOnJS(setFingerX)(fingerX)
       }
     },


### PR DESCRIPTION
## Description
`fingerX` was using a late value to show circle on graph after [this change](https://github.com/margelo/react-native-graph/pull/16)

## Demo

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td>
<video width="340" alt="image" src="https://user-images.githubusercontent.com/42688281/180667170-3df04f1a-6b34-4a67-bffc-42475f24ff2b.mp4">
</td>
    <td>
<video width="340" alt="video" src="https://user-images.githubusercontent.com/42688281/180667177-0ca77e58-e409-4560-9626-e70f38607bab.mp4">
</td>
</table>







