### PR TITLE
fix: remove duplicate babel.config.js

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,3 +1,0 @@
-module.exports = {
-  presets: ['module:metro-react-native-babel-preset'],
-};


### PR DESCRIPTION
# Description

~~Running `yarn lint` after pulling the repository, will return an error without having made any change yet.~~

Changed the PR. Found out this [babel.config.js](https://github.com/margelo/react-native-graph/blob/main/babel.config.js) not being used, because there's already  [example/babel.config.js](https://github.com/margelo/react-native-graph/blob/main/example/babel.config.js).