### PR TITLE
fix: weird typescript ReactNode errors

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -28,5 +28,8 @@
     "@types/react-native": "^0.67.4",
     "babel-plugin-module-resolver": "^4.0.0",
     "metro-react-native-babel-preset": "^0.66.2"
+  },
+  "resolutions": {
+    "@types/react": "^17.0.42"
   }
 }

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -1043,16 +1043,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*":
-  version "18.0.8"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.8.tgz#a051eb380a9fbcaa404550543c58e1cf5ce4ab87"
-  integrity sha512-+j2hk9BzCOrrOSJASi5XiOyBbERk9jG5O73Ya4M0env5Ixi6vUNli4qy994AINcEF+1IEHISYFfIT4zwr++LKw==
-  dependencies:
-    "@types/prop-types" "*"
-    "@types/scheduler" "*"
-    csstype "^3.0.2"
-
-"@types/react@^17.0.42":
+"@types/react@*", "@types/react@^17.0.42":
   version "17.0.44"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.44.tgz#c3714bd34dd551ab20b8015d9d0dbec812a51ec7"
   integrity sha512-Ye0nlw09GeMp2Suh8qoOv0odfgCoowfM/9MG6WeRD60Gq9wS90bdkdRtYbRkNhXOpG4H+YXGvj4wOWhAC0LJ1g==

--- a/package.json
+++ b/package.json
@@ -80,6 +80,9 @@
     "react-native-reanimated": ">=2",
     "react-native-gesture-handler": ">=2"
   },
+  "resolutions": {
+    "@types/react": "^17.0.42"
+  },
   "release-it": {
     "git": {
       "commitMessage": "chore: release ${version}",

--- a/src/AnimatedLineGraph.tsx
+++ b/src/AnimatedLineGraph.tsx
@@ -26,9 +26,6 @@ import { GestureDetector } from 'react-native-gesture-handler'
 import { useHoldOrPanGesture } from './hooks/useHoldOrPanGesture'
 import { getYForX } from './GetYForX'
 
-// weird rea type bug
-const ReanimatedView = Reanimated.View as any
-
 export function AnimatedLineGraph({
   points,
   color,
@@ -231,7 +228,7 @@ export function AnimatedLineGraph({
   return (
     <View {...props}>
       <GestureDetector gesture={enablePanGesture ? gesture : undefined}>
-        <ReanimatedView style={styles.container}>
+        <Reanimated.View style={styles.container}>
           {/* Top Label (max price) */}
           {TopAxisLabel != null && (
             <View style={styles.axisRow}>
@@ -288,7 +285,7 @@ export function AnimatedLineGraph({
               <BottomAxisLabel />
             </View>
           )}
-        </ReanimatedView>
+        </Reanimated.View>
       </GestureDetector>
     </View>
   )

--- a/yarn.lock
+++ b/yarn.lock
@@ -1617,16 +1617,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*":
-  version "18.0.8"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.8.tgz#a051eb380a9fbcaa404550543c58e1cf5ce4ab87"
-  integrity sha512-+j2hk9BzCOrrOSJASi5XiOyBbERk9jG5O73Ya4M0env5Ixi6vUNli4qy994AINcEF+1IEHISYFfIT4zwr++LKw==
-  dependencies:
-    "@types/prop-types" "*"
-    "@types/scheduler" "*"
-    csstype "^3.0.2"
-
-"@types/react@^17.0.42":
+"@types/react@*", "@types/react@^17.0.42":
   version "17.0.44"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.44.tgz#c3714bd34dd551ab20b8015d9d0dbec812a51ec7"
   integrity sha512-Ye0nlw09GeMp2Suh8qoOv0odfgCoowfM/9MG6WeRD60Gq9wS90bdkdRtYbRkNhXOpG4H+YXGvj4wOWhAC0LJ1g==


### PR DESCRIPTION
# Description

Encountered several weird TypeScript errors, when working in this repository:

```jsx
'Reanimated.View' cannot be used as a JSX component.
  Its instance type 'View' is not a valid JSX element.
    The types returned by 'render()' are incompatible between these types.
      Type 'React.ReactNode' is not assignable to type 'import("/Users/xxx/react-native-graph/node_modules/@types/react-native/node_modules/@types/react/index").ReactNode'.
        Type '{}' is not assignable to type 'ReactNode'.
```

Seems @mrousavy encountered the same looking at this `as any`:
https://github.com/margelo/react-native-graph/blob/main/src/AnimatedLineGraph.tsx#L29-L30

# Cause

Tracked down to this https://github.com/facebook/react/issues/24304, stating:

> some library (incorrectly) specifies @types/react as a dependency with version * rather than an optional peer dependency

```jsx
// in @types/react v17:
type ReactFragment = {} | ReactNodeArray;

// in @types/react v18:
type ReactFragment = Iterable<ReactNode>;
```

# Fix

A comment from a React contributor https://github.com/facebook/react/issues/24304#issuecomment-1094565891 suggests to force `@types/react@*` to your React 17 version by using `overrides` (npm) or `resolutions` (yarn).

Even better is to open an issue at the responding library's repo.

@mrousavy I'm fine with closing this PR, because it's a suboptimal fix (and making `package.json` grow even further). In any case, now you know what is causing these errors and this fixes it for the time being. It's your choice.