### PR TITLE
Fixed a Typo in Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ yarn add <b>react-native-graph</b>
 function App() {
   const priceHistory = usePriceHistory('ethereum')
 
-  return <LineGraph points={priceHistory} />
+  return <LineGraph points={priceHistory} color="#4484B2" />
 }
 ```
 
@@ -62,6 +62,7 @@ Example:
 <LineGraph
   points={priceHistory}
   animated={true}
+  color="#4484B2"
 />
 ```
 
@@ -87,6 +88,7 @@ Example:
 <LineGraph
   points={priceHistory}
   animated={true}
+  color="#4484B2"
   enablePanGesture={true}
   onGestureStart={() => hapticFeedback('impactLight')}
   onPointSelected={(p) => updatePriceTitle(p)}
@@ -112,6 +114,7 @@ Example:
 <LineGraph
   points={priceHistory}
   animated={true}
+  color="#4484B2"
   TopAxisLabel={() => <AxisLabel x={max.x} value={max.value} />}
   BottomAxisLabel={() => <AxisLabel x={min.x} value={min.value} />}
 />
@@ -133,6 +136,7 @@ Example:
 <LineGraph
   points={priceHistory}
   animated={true}
+  color="#4484B2"
   enablePanGesture={true}
   selectionDotShadowColor="#333333"
 />


### PR DESCRIPTION
Added a color prop when using Linegraph Component. The reason for updating the documentation is that I encountered an error when I was following it when developing using Expo Go. 
Error: [TypeError: undefined is not an object (evaluating 'color.startsWith')]
Solution: I added a color prop to Linegraph Component but that was not mentioned in the documentation.