### PR TITLE
Fix: Graph inaccuracies with range applied

### DIFF
--- a/src/AnimatedLineGraph.tsx
+++ b/src/AnimatedLineGraph.tsx
@@ -143,7 +143,9 @@ export function AnimatedLineGraph({
   }, [horizontalPadding, width])
 
   const lineWidth = useMemo(() => {
-    const lastPoint = points[points.length - 1]!
+    const lastPoint = points[points.length - 1]
+
+    if (lastPoint == null) return width - 2 * horizontalPadding
 
     return Math.max(
       Math.floor(

--- a/src/AnimatedLineGraph.tsx
+++ b/src/AnimatedLineGraph.tsx
@@ -24,6 +24,7 @@ import {
   createGraphPathWithGradient,
   getGraphPathRange,
   GraphPathRange,
+  pixelFactorX,
 } from './CreateGraphPath'
 import Reanimated, {
   runOnJS,
@@ -141,12 +142,24 @@ export function AnimatedLineGraph({
     return Math.max(Math.floor(width - 2 * horizontalPadding), 0)
   }, [horizontalPadding, width])
 
+  const lineWidth = useMemo(() => {
+    const lastPoint = points[points.length - 1]!
+
+    return Math.max(
+      Math.floor(
+        (width - 2 * horizontalPadding) *
+          pixelFactorX(lastPoint.date, pathRange.x.min, pathRange.x.max)
+      ),
+      0
+    )
+  }, [horizontalPadding, pathRange.x.max, pathRange.x.min, points, width])
+
   const indicatorX = useMemo(
     () =>
       commandsChanged >= 0
-        ? Math.floor(drawingWidth) + horizontalPadding
+        ? Math.floor(lineWidth) + horizontalPadding
         : undefined,
-    [commandsChanged, drawingWidth, horizontalPadding]
+    [commandsChanged, horizontalPadding, lineWidth]
   )
   const indicatorY = useMemo(
     () =>

--- a/src/AnimatedLineGraph.tsx
+++ b/src/AnimatedLineGraph.tsx
@@ -345,7 +345,6 @@ export function AnimatedLineGraph({
       const pointIndex = Math.min(Math.max(index, 0), points.length - 1)
 
       if (pointSelectedIndex.current !== pointIndex) {
-        console.log(pointIndex)
         const dataPoint = points[pointIndex]
         pointSelectedIndex.current = pointIndex
 

--- a/src/CreateGraphPath.ts
+++ b/src/CreateGraphPath.ts
@@ -87,8 +87,9 @@ export function getGraphPathRange(
   points: GraphPoint[],
   range?: GraphRange
 ): GraphPathRange {
-  const minValueX = range?.x?.min ?? points[0]!.date
-  const maxValueX = range?.x?.max ?? points[points.length - 1]!.date
+  const minValueX = range?.x?.min ?? points[0]?.date ?? new Date()
+  const maxValueX =
+    range?.x?.max ?? points[points.length - 1]?.date ?? new Date()
 
   const minValueY =
     range?.y?.min ??


### PR DESCRIPTION
When a `range` is applied to the graph, the `onPointSelected()` callback might be called at the wrong time.

This PR fixes this problem and also generally improves how and when `onPointSelected()` is triggered.