### PR TITLE
fix: Remove incorrect delta from pixel factor calculation

### DIFF
--- a/example/src/data/GraphData.ts
+++ b/example/src/data/GraphData.ts
@@ -11,7 +11,9 @@ export function generateRandomGraphData(length: number): GraphPoint[] {
   return Array<number>(length)
     .fill(0)
     .map((_, index) => ({
-      date: new Date(index),
+      date: new Date(
+        new Date(2000, 0, 1).getTime() + 1000 * 60 * 60 * 24 * index
+      ),
       value: weightedRandom(10, Math.pow(index + 1, 2)),
     }))
 }

--- a/src/CreateGraphPath.ts
+++ b/src/CreateGraphPath.ts
@@ -220,11 +220,7 @@ function createGraphPathBase({
 
     // Calculates how many points between two points must be
     // calculated and drawn onto the canvas
-    const drawingFactor = pixelFactorX(
-      new Date(point.date.getTime() - prev.date.getTime()),
-      range.x.min,
-      range.x.max
-    )
+    const drawingFactor = pixelFactorX(point.date, range.x.min, range.x.max)
     const drawingPixels = actualWidth * drawingFactor + horizontalPadding
     const numberOfDrawingPoints = Math.floor(drawingPixels / PIXEL_RATIO)
 

--- a/src/CreateGraphPath.ts
+++ b/src/CreateGraphPath.ts
@@ -220,7 +220,9 @@ function createGraphPathBase({
 
     // Calculates how many points between two points must be
     // calculated and drawn onto the canvas
-    const drawingFactor = pixelFactorX(point.date, range.x.min, range.x.max)
+    const spanX = range.x.max.getTime() - range.x.min.getTime()
+    const deltaX = point.date.getTime() - prev.date.getTime()
+    const drawingFactor = deltaX / spanX
     const drawingPixels = actualWidth * drawingFactor + horizontalPadding
     const numberOfDrawingPoints = Math.floor(drawingPixels / PIXEL_RATIO)
 


### PR DESCRIPTION
This PR fixes an issue identified where some later dates in the points data would cause NaNs in the cubic path calculation. Once I removed the delta value for the `pixelFactorX` calculation the graph rendered correctly with a valid path.

I'm not fully sure I understand why this fixes it so would be great if you could shed some light here @chrispader and make sure I'm not breaking something else with this change 😄