### PR TITLE
fix: graph is not showing if all points have same value

### DIFF
--- a/src/CreateGraphPath.ts
+++ b/src/CreateGraphPath.ts
@@ -101,6 +101,8 @@ export const getYPositionInRange = (
   value: number,
   yRange: GraphYRange
 ): number => {
+  if (yRange.min === yRange.max) return 0.5 // Prevent division by zero (NaN)
+
   const diff = yRange.max - yRange.min
   const y = value
 


### PR DESCRIPTION
If all points have same value and graph is just "straight line" it will cause function `getYPositionInRange` return NaN, which will cause that graph line is not displayed at all.