### PR TITLE
feat: add ability to plot non-exact points (`checkExactPoints` prop)

### DIFF
--- a/src/AnimatedLineGraph.tsx
+++ b/src/AnimatedLineGraph.tsx
@@ -71,6 +71,7 @@ export function AnimatedLineGraph({
   verticalPadding = lineThickness,
   TopAxisLabel,
   BottomAxisLabel,
+  checkExactPoints = true,
   ...props
 }: AnimatedLineGraphProps): React.ReactElement {
   const [width, setWidth] = useState(0)
@@ -196,6 +197,7 @@ export function AnimatedLineGraph({
       verticalPadding,
       canvasHeight: height,
       canvasWidth: width,
+      checkExactPoints,
     }
 
     if (shouldFillGradient) {

--- a/src/CreateGraphPath.ts
+++ b/src/CreateGraphPath.ts
@@ -43,6 +43,12 @@ type GraphPathConfig = {
    * Range of the graph's x and y-axis
    */
   range: GraphPathRange
+  /**
+   * Boolean flag to check if the point is exact.
+   * If true, only exact points will be drawn. If false, all points will be drawn.
+   * Default is true.
+   */
+  checkExactPoints: boolean
 }
 
 type GraphPathConfigWithGradient = GraphPathConfig & {
@@ -140,6 +146,7 @@ function createGraphPathBase({
   canvasHeight: height,
   canvasWidth: width,
   shouldFillGradient,
+  checkExactPoints,
 }: GraphPathConfigWithGradient | GraphPathConfigWithoutGradient):
   | SkPath
   | GraphPathWithGradient {
@@ -181,7 +188,7 @@ function createGraphPathBase({
 
     if (index === graphData.length - 1 && pixel !== endX) continue
 
-    if (index !== 0 && index !== graphData.length - 1) {
+    if (checkExactPoints && index !== 0 && index !== graphData.length - 1) {
       // Only draw point, when the point is exact
       const exactPointX =
         getXInRange(drawingWidth, graphData[index]!.date, range.x) +

--- a/src/LineGraphProps.ts
+++ b/src/LineGraphProps.ts
@@ -47,6 +47,12 @@ interface BaseLineGraphProps extends ViewProps {
    * Enable the Fade-In Gradient Effect at the beginning of the Graph
    */
   enableFadeInMask?: boolean
+  /**
+   * Boolean flag to check if the point is exact.
+   * If true, only exact points will be drawn. If false, all points will be drawn.
+   * Default is true.
+   */
+  checkExactPoints?: boolean
 }
 
 export type StaticLineGraphProps = BaseLineGraphProps & {

--- a/src/StaticLineGraph.tsx
+++ b/src/StaticLineGraph.tsx
@@ -17,6 +17,7 @@ export function StaticLineGraph({
   lineThickness = 3,
   enableFadeInMask,
   style,
+  checkExactPoints = true,
   ...props
 }: StaticLineGraphProps): React.ReactElement {
   const [width, setWidth] = useState(0)
@@ -49,8 +50,9 @@ export function StaticLineGraph({
         canvasWidth: width,
         horizontalPadding: lineThickness,
         verticalPadding: lineThickness,
+        checkExactPoints,
       }),
-    [height, lineThickness, pathRange, pointsInRange, width]
+    [checkExactPoints, height, lineThickness, pathRange, pointsInRange, width]
   )
 
   const gradientColors = useMemo(


### PR DESCRIPTION
Add `checkExactPoints` props, setting to false allows to skip the check for exact graph points so that all points can be plotted accurately
`checkExactPoints` defaults to `true` to be backwards compatible 

`checkExactPoints={true}` vs `checkExactPoints={false}`  👇
![imgonline-com-ua-twotoone-owbliWPCcpf3OI0v](https://github.com/margelo/react-native-graph/assets/13225248/b8bd0a01-46c1-4b98-8f27-6a8431b1eca2)
