### PR TITLE
Fix: animate graph on data changes

### DIFF
--- a/src/AnimatedLineGraph.tsx
+++ b/src/AnimatedLineGraph.tsx
@@ -249,6 +249,7 @@ export function AnimatedLineGraph({
 
     setCommandsChanged(commandsChanged + 1)
 
+    interpolateProgress.value = 0
     interpolateProgress.value = withSpring(1, {
       mass: 1,
       stiffness: 500,


### PR DESCRIPTION
Running the example project and clicking the "Refresh" button under the graph to change the graph's data does not result in the graph animating from the initial data to the new data for me. This 1-line change gets animations on data changes working as expected. Fixes #115 