### PR TITLE
fix: call onPointSelected only when gesture is active

### DIFF
--- a/src/AnimatedLineGraph.tsx
+++ b/src/AnimatedLineGraph.tsx
@@ -140,7 +140,7 @@ export function AnimatedLineGraph({
   const gradientPaths = useSharedValue<{ from?: SkPath; to?: SkPath }>({})
   const commands = useSharedValue<PathCommand[]>([])
   const [commandsChanged, setCommandsChanged] = useState(0)
-  const pointSelectedIndex = useRef<number>()
+  const pointSelectedIndex = useRef<number | undefined>(undefined)
 
   const pathRange: GraphPathRange = useMemo(
     () => getGraphPathRange(allPoints, range),
@@ -352,7 +352,7 @@ export function AnimatedLineGraph({
         const dataPoint = pointsInRange[pointIndex]
         pointSelectedIndex.current = pointIndex
 
-        if (dataPoint != null) {
+        if (dataPoint != null && isActive.value) {
           onPointSelected?.(dataPoint)
         }
       }
@@ -363,6 +363,7 @@ export function AnimatedLineGraph({
       onPointSelected,
       pathRange.x,
       pointsInRange,
+      isActive,
     ]
   )
 


### PR DESCRIPTION
There's an issue happening when you change `points` after having activated the gesture once. The `onPointSelected` callback is executed even though there's no gesture active at the moment. You can see the problem in the video below. You'll notice that the current price changes to a "random" value that's actually what's being passed to `onPointSelected` when the `points` prop change.

https://github.com/user-attachments/assets/df8236b8-8f95-40d3-94a0-a1bbf4230ba8



After the fix, the behavior is what I believe to be expected: the `onPointSelected` callback is not called after changing the `points`.

https://github.com/user-attachments/assets/da6e961c-6620-400e-805b-991166ea0a18


