### PR TITLE
fix: reset gesture state in onFinalize (selection dot left stuck on cancel)

### DIFF
--- a/src/hooks/usePanGesture.ts
+++ b/src/hooks/usePanGesture.ts
@@ -35,6 +35,13 @@ export function usePanGesture({ enabled, holdDuration = 300 }: Config): Result {
         })
         .onEnd(() => {
           isPanGestureActive.value = false;
+        })
+        // `onEnd` does not fire when the gesture is cancelled or interrupted
+        // (e.g. a parent ScrollView/FlatList takes over the pan). `onFinalize`
+        // always runs, so reset here too — otherwise `isActive` stays `true` and
+        // the selection dot / scrub stays stuck visible after the finger lifts.
+        .onFinalize(() => {
+          isPanGestureActive.value = false;
         }),
     [enabled, holdDuration, isPanGestureActive, x, y]
   );


### PR DESCRIPTION
## Summary

`usePanGesture` only resets `isPanGestureActive` in `.onEnd()`. But `onEnd` does **not** fire when the pan gesture is cancelled or interrupted — most commonly when the graph is rendered inside a `ScrollView` / `FlatList` and the parent scroll takes over the pan. When that happens `isActive` stays `true`, so the selection dot / scrub overlay stays visible after the finger has lifted.

`.onFinalize()` always runs at the end of a gesture (whether it completed or was cancelled), so this resets the active state there too.

## Change

```diff
         .onEnd(() => {
           isPanGestureActive.value = false;
+        })
+        .onFinalize(() => {
+          isPanGestureActive.value = false;
         }),
```

One-line behavioural change plus an explanatory comment.

## Notes
- No API change, fully backwards compatible.
- `yarn typecheck` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
