### PR TITLE
fix: handle graph points sharing one pixel

### DIFF
--- a/src/CreateGraphPath.ts
+++ b/src/CreateGraphPath.ts
@@ -162,7 +162,11 @@ function createGraphPathBase({
     horizontalPadding;
 
   const getGraphDataIndex = (pixel: number) =>
-    Math.round(((pixel - startX) / (endX - startX)) * (graphData.length - 1));
+    endX === startX
+      ? 0
+      : Math.round(
+          ((pixel - startX) / (endX - startX)) * (graphData.length - 1)
+        );
 
   const getNextPixelValue = (pixel: number) => {
     if (pixel === endX || pixel + PIXEL_RATIO < endX)

--- a/src/__tests__/CreateGraphPath.test.ts
+++ b/src/__tests__/CreateGraphPath.test.ts
@@ -1,0 +1,45 @@
+const mockPath = {
+  copy: jest.fn(),
+  cubicTo: jest.fn(),
+  lineTo: jest.fn(),
+  moveTo: jest.fn(),
+};
+
+jest.mock('@shopify/react-native-skia', () => ({
+  Skia: {
+    Path: {
+      Make: () => mockPath,
+    },
+  },
+}));
+
+import { createGraphPath } from '../CreateGraphPath';
+
+beforeEach(() => jest.clearAllMocks());
+
+it('creates a finite path when every graph point maps to the same pixel', () => {
+  const points = [
+    { date: new Date(2024, 1, 1), value: 10 },
+    { date: new Date(2024, 2, 1), value: 100 },
+  ];
+
+  expect(() =>
+    createGraphPath({
+      pointsInRange: points,
+      range: {
+        x: {
+          min: new Date(2024, 1, 1),
+          max: new Date(2070, 2, 1),
+        },
+        y: { min: 0, max: 100 },
+      },
+      horizontalPadding: 0,
+      verticalPadding: 0,
+      canvasHeight: 200,
+      canvasWidth: 300,
+    })
+  ).not.toThrow();
+
+  expect(mockPath.moveTo).toHaveBeenCalledTimes(1);
+  expect(mockPath.moveTo.mock.calls[0]?.every(Number.isFinite)).toBe(true);
+});


### PR DESCRIPTION
## Summary

- Handle graph ranges where every data point resolves to the same canvas pixel.
- Avoid dividing by a zero pixel span and producing a NaN graph-data index.
- Add regression coverage using the dates and wide range shape from #95.

## Root cause

The path sampler derives an array index from the relative pixel position. With a very wide X range, flooring can map both the first and last graph points to the same pixel. The resulting endX - startX value is zero, so the computed index becomes NaN and the code reads graphData[NaN].date.

A zero-width pixel span has only one drawable pixel. The sampler now selects index zero for that degenerate case while leaving the existing interpolation unchanged for every non-zero span.

## Validation

- yarn typecheck
- yarn lint (0 errors; existing no-shadow warning in AnimatedLineGraph.tsx)
- yarn test --runInBand
- yarn prepare

The regression test failed on main with Cannot read properties of undefined (reading date), then passed with a finite path after the guard.

Fixes #95.