### PR TITLE
fix: make animated prop optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ function App() {
 
 Whether to animate between data changes.
 
+Defaults to `false` when omitted.
+
 Animations are ran using the [Skia animation system](https://shopify.github.io/react-native-skia/docs/animations/animations) and are fully natively interpolated to ensure best possible performance.
 
 If `animated` is `false`, a light-weight implementation of the graph renderer will be used, which is optimal for displaying a lot of graphs in large lists.

--- a/README.md
+++ b/README.md
@@ -55,9 +55,7 @@ function App() {
 
 <img src="./img/change.gif" align="right" height="250" />
 
-Whether to animate between data changes.
-
-Defaults to `false` when omitted.
+Whether to animate between data changes. Defaults to `false` when omitted.
 
 Animations are ran using the [Skia animation system](https://shopify.github.io/react-native-skia/docs/animations/animations) and are fully natively interpolated to ensure best possible performance.
 

--- a/src/LineGraphProps.ts
+++ b/src/LineGraphProps.ts
@@ -113,4 +113,4 @@ export type AnimatedLineGraphProps = BaseLineGraphProps & {
 
 export type LineGraphProps =
   | ({ animated: true } & AnimatedLineGraphProps)
-  | ({ animated: false } & StaticLineGraphProps);
+  | ({ animated?: false } & StaticLineGraphProps);

--- a/src/__tests__/LineGraphProps.test.ts
+++ b/src/__tests__/LineGraphProps.test.ts
@@ -1,0 +1,29 @@
+import type { LineGraphProps } from '../LineGraphProps';
+
+const points = [
+  { value: 1, date: new Date('2026-01-01T00:00:00.000Z') },
+  { value: 2, date: new Date('2026-01-02T00:00:00.000Z') },
+];
+
+function acceptLineGraphProps(props: LineGraphProps): LineGraphProps {
+  return props;
+}
+
+describe('LineGraphProps', () => {
+  it('defaults to the static graph when animated is omitted', () => {
+    const props = acceptLineGraphProps({ points, color: '#4484B2' });
+
+    expect(props.animated).toBeUndefined();
+  });
+
+  it('accepts animated renderer props with animated=true', () => {
+    const props = acceptLineGraphProps({
+      points,
+      color: '#4484B2',
+      animated: true,
+      enablePanGesture: true,
+    });
+
+    expect(props.animated).toBe(true);
+  });
+});


### PR DESCRIPTION
Fixes #94

## Summary

- make `animated` optional on the static `LineGraph` branch
- document that omitting it defaults to static rendering
- add a TypeScript regression proving both the omitted and animated forms compile

## Why

The runtime already treats a missing `animated` value as false:

```tsx
if (props.animated) return <AnimatedLineGraph {...props} />;
return <StaticLineGraph {...props} />;
```

The public discriminated union nevertheless required consumers to pass either `animated={true}` or `animated={false}`. This aligns the type with the existing runtime behavior without adding animation work or changing the animated path.

## Validation

- `yarn install --immutable` (Node 22.20.0 / Yarn 4.11.0)
- `yarn typecheck`
- `yarn test --runInBand` — 1 suite, 2/2 tests passed
- `yarn prepare`
- `yarn lint` — 0 errors; one existing `no-shadow` warning in unchanged `AnimatedLineGraph.tsx`
- `yarn prettier --check src/LineGraphProps.ts src/__tests__/LineGraphProps.test.ts`
- `git diff --check`

The new type regression failed on `main` because the prop was required, then passed after the union change.
