### PR TITLE
fix: remove worklets peer dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 ## Installation
 
 <pre>
-yarn add <a href="https://github.com/software-mansion/react-native-reanimated">react-native-reanimated</a>
+yarn add <a href="https://github.com/software-mansion/react-native-reanimated">react-native-reanimated</a> # Reanimated requires <a href="https://github.com/software-mansion/react-native-reanimated/tree/main/packages/react-native-worklets">react-native-worklets</a>
 yarn add <a href="https://github.com/software-mansion/react-native-gesture-handler">react-native-gesture-handler</a>
 yarn add <a href="https://github.com/Shopify/react-native-skia">@shopify/react-native-skia</a>
 yarn add <b>react-native-graph</b>

--- a/package.json
+++ b/package.json
@@ -104,8 +104,7 @@
   "peerDependencies": {
     "react": "*",
     "react-native": "*",
-    "react-native-reanimated": "*",
-    "react-native-worklets": "*"
+    "react-native-reanimated": "*"
   },
   "workspaces": [
     "example"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10758,7 +10758,6 @@ __metadata:
     react: "*"
     react-native: "*"
     react-native-reanimated: "*"
-    react-native-worklets: "*"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
`react-native-graph` currently declares `react-native-worklets` as a peer for every consumer, even though it only imports APIs from Reanimated. This can impose Worklets on Reanimated 3 users, although Reanimated 3 is incompatible with it and Reanimated 4 already declares a compatible Worklets range. This PR removes the redundant peer, keeps Worklets for development and the example app, and adds an inline README note beside the Reanimated installation command.