### PR TITLE
fix: render points sharing one date

### DIFF
--- a/src/CreateGraphPath.ts
+++ b/src/CreateGraphPath.ts
@@ -87,6 +87,10 @@ export const getXPositionInRange = (
   const diff = xRange.max.getTime() - xRange.min.getTime();
   const x = date.getTime();
 
+  if (diff === 0) {
+    return x === xRange.min.getTime() ? 0.5 : Number.NaN;
+  }
+
   return (x - xRange.min.getTime()) / diff;
 };
 
@@ -174,41 +178,54 @@ function createGraphPathBase({
     return endX;
   };
 
-  for (
-    let pixel = startX;
-    startX <= pixel && pixel <= endX;
-    pixel = getNextPixelValue(pixel)
-  ) {
-    const index = getGraphDataIndex(pixel);
-
-    // Draw first point only on the very first pixel
-    if (index === 0 && pixel !== startX) continue;
-    // Draw last point only on the very last pixel
-
-    if (index === graphData.length - 1 && pixel !== endX) continue;
-
-    if (index !== 0 && index !== graphData.length - 1) {
-      // Only draw point, when the point is exact
-      const exactPointX =
-        getXInRange(drawingWidth, graphData[index]!.date, range.x) +
-        horizontalPadding;
-
-      const isExactPointInsidePixelRatio = Array(PIXEL_RATIO)
-        .fill(0)
-        .some((_value, additionalPixel) => {
-          return pixel + additionalPixel === exactPointX;
-        });
-
-      if (!isExactPointInsidePixelRatio) continue;
-    }
-
+  const addPoint = (index: number, x: number) => {
     const value = graphData[index]!.value;
     const y =
       drawingHeight -
       getYInRange(drawingHeight, value, range.y) +
       verticalPadding;
 
-    points.push({ x: pixel, y: y });
+    points.push({ x, y });
+  };
+
+  const firstPointTime = graphData[0]!.date.getTime();
+  const allPointsShareDate = graphData.every(
+    (point) => point.date.getTime() === firstPointTime
+  );
+
+  if (endX === startX && allPointsShareDate) {
+    graphData.forEach((_point, index) => addPoint(index, startX));
+  } else {
+    for (
+      let pixel = startX;
+      startX <= pixel && pixel <= endX;
+      pixel = getNextPixelValue(pixel)
+    ) {
+      const index = getGraphDataIndex(pixel);
+
+      // Draw first point only on the very first pixel
+      if (index === 0 && pixel !== startX) continue;
+      // Draw last point only on the very last pixel
+
+      if (index === graphData.length - 1 && pixel !== endX) continue;
+
+      if (index !== 0 && index !== graphData.length - 1) {
+        // Only draw point, when the point is exact
+        const exactPointX =
+          getXInRange(drawingWidth, graphData[index]!.date, range.x) +
+          horizontalPadding;
+
+        const isExactPointInsidePixelRatio = Array(PIXEL_RATIO)
+          .fill(0)
+          .some((_value, additionalPixel) => {
+            return pixel + additionalPixel === exactPointX;
+          });
+
+        if (!isExactPointInsidePixelRatio) continue;
+      }
+
+      addPoint(index, pixel);
+    }
   }
 
   for (let i = 0; i < points.length; i++) {

--- a/src/__tests__/CreateGraphPath.test.ts
+++ b/src/__tests__/CreateGraphPath.test.ts
@@ -13,7 +13,11 @@ jest.mock('@shopify/react-native-skia', () => ({
   },
 }));
 
-import { createGraphPath } from '../CreateGraphPath';
+import {
+  createGraphPath,
+  getGraphPathRange,
+  getPointsInRange,
+} from '../CreateGraphPath';
 
 beforeEach(() => jest.clearAllMocks());
 
@@ -42,4 +46,48 @@ it('creates a finite path when every graph point maps to the same pixel', () => 
 
   expect(mockPath.moveTo).toHaveBeenCalledTimes(1);
   expect(mockPath.moveTo.mock.calls[0]?.every(Number.isFinite)).toBe(true);
+});
+
+it('creates a visible path when graph points share the same date', () => {
+  const date = new Date('2023-01-01');
+  const points = [
+    { date, value: 1 },
+    { date, value: 2 },
+  ];
+  const range = getGraphPathRange(points);
+  const pointsInRange = getPointsInRange(points, range);
+
+  createGraphPath({
+    pointsInRange,
+    range,
+    horizontalPadding: 0,
+    verticalPadding: 0,
+    canvasHeight: 200,
+    canvasWidth: 300,
+  });
+
+  expect(pointsInRange).toEqual(points);
+  expect(mockPath.moveTo).toHaveBeenCalledTimes(1);
+  expect(mockPath.cubicTo).toHaveBeenCalled();
+  expect(
+    [...mockPath.moveTo.mock.calls, ...mockPath.cubicTo.mock.calls]
+      .flat()
+      .every(Number.isFinite)
+  ).toBe(true);
+});
+
+it('filters different dates from a zero-duration range', () => {
+  const date = new Date('2023-01-01');
+  const points = [
+    { date: new Date('2022-12-31'), value: 1 },
+    { date, value: 2 },
+    { date: new Date('2023-01-02'), value: 3 },
+  ];
+
+  expect(
+    getPointsInRange(points, {
+      x: { min: date, max: date },
+      y: { min: 1, max: 3 },
+    })
+  ).toEqual([points[1]]);
 });


### PR DESCRIPTION
## Summary

- keep matching points inside a zero-duration X range
- center the degenerate range on the canvas
- draw every value at the shared X coordinate so Skia receives a visible vertical path

## Root cause

When the first and last timestamps are equal, X normalization divides by zero. The resulting NaN causes getPointsInRange to discard every point before path creation. Even after normalizing the shared timestamp, the one-pixel sampler selects only the first point, leaving Skia with a move command but no drawable segment.

The patch maps the shared timestamp to the center of the range, rejects non-matching timestamps from an explicit zero-duration range, and preserves all same-date values at that X coordinate. The existing behavior for different dates that merely floor to one canvas pixel remains unchanged.

## Validation

Using the repository Node.js version (22.20.0):

- yarn test --runInBand — 5/5 tests pass
- yarn typecheck
- yarn lint — 0 errors; one existing no-shadow warning in AnimatedLineGraph.tsx
- yarn prepare
- git diff --check

Fixes #86