### PR TITLE
fix: preserve irregularly spaced graph points

### DIFF
--- a/src/CreateGraphPath.ts
+++ b/src/CreateGraphPath.ts
@@ -155,60 +155,33 @@ function createGraphPathBase({
 
   const points: SkPoint[] = [];
 
-  const startX =
-    getXInRange(drawingWidth, graphData[0]!.date, range.x) + horizontalPadding;
   const endX =
     getXInRange(drawingWidth, graphData[graphData.length - 1]!.date, range.x) +
     horizontalPadding;
 
-  const getGraphDataIndex = (pixel: number) =>
-    endX === startX
-      ? 0
-      : Math.round(
-          ((pixel - startX) / (endX - startX)) * (graphData.length - 1)
-        );
+  let lastDrawnX: number | undefined;
 
-  const getNextPixelValue = (pixel: number) => {
-    if (pixel === endX || pixel + PIXEL_RATIO < endX)
-      return pixel + PIXEL_RATIO;
-    return endX;
-  };
+  for (let index = 0; index < graphData.length; index++) {
+    const graphPoint = graphData[index]!;
+    const x =
+      getXInRange(drawingWidth, graphPoint.date, range.x) + horizontalPadding;
+    const isBoundaryPoint = index === 0 || index === graphData.length - 1;
 
-  for (
-    let pixel = startX;
-    startX <= pixel && pixel <= endX;
-    pixel = getNextPixelValue(pixel)
-  ) {
-    const index = getGraphDataIndex(pixel);
-
-    // Draw first point only on the very first pixel
-    if (index === 0 && pixel !== startX) continue;
-    // Draw last point only on the very last pixel
-
-    if (index === graphData.length - 1 && pixel !== endX) continue;
-
-    if (index !== 0 && index !== graphData.length - 1) {
-      // Only draw point, when the point is exact
-      const exactPointX =
-        getXInRange(drawingWidth, graphData[index]!.date, range.x) +
-        horizontalPadding;
-
-      const isExactPointInsidePixelRatio = Array(PIXEL_RATIO)
-        .fill(0)
-        .some((_value, additionalPixel) => {
-          return pixel + additionalPixel === exactPointX;
-        });
-
-      if (!isExactPointInsidePixelRatio) continue;
+    if (
+      !isBoundaryPoint &&
+      lastDrawnX != null &&
+      x - lastDrawnX < PIXEL_RATIO
+    ) {
+      continue;
     }
 
-    const value = graphData[index]!.value;
     const y =
       drawingHeight -
-      getYInRange(drawingHeight, value, range.y) +
+      getYInRange(drawingHeight, graphPoint.value, range.y) +
       verticalPadding;
 
-    points.push({ x: pixel, y: y });
+    points.push({ x, y });
+    lastDrawnX = x;
   }
 
   for (let i = 0; i < points.length; i++) {

--- a/src/__tests__/CreateGraphPath.test.ts
+++ b/src/__tests__/CreateGraphPath.test.ts
@@ -43,3 +43,25 @@ it('creates a finite path when every graph point maps to the same pixel', () => 
   expect(mockPath.moveTo).toHaveBeenCalledTimes(1);
   expect(mockPath.moveTo.mock.calls[0]?.every(Number.isFinite)).toBe(true);
 });
+
+it('preserves intermediate points with irregular timestamp spacing', () => {
+  const points = [
+    { date: new Date(0), value: 0 },
+    { date: new Date(3), value: 100 },
+    { date: new Date(10), value: 0 },
+  ];
+
+  createGraphPath({
+    pointsInRange: points,
+    range: {
+      x: { min: points[0]!.date, max: points[2]!.date },
+      y: { min: 0, max: 100 },
+    },
+    horizontalPadding: 0,
+    verticalPadding: 0,
+    canvasHeight: 100,
+    canvasWidth: 10,
+  });
+
+  expect(mockPath.cubicTo).toHaveBeenCalledTimes(3);
+});


### PR DESCRIPTION
## Summary

- sample graph data using each point's timestamp-derived X coordinate
- preserve irregularly spaced intermediate values that the index-based sampler skipped
- keep the existing two-pixel density cap and always retain boundary points

Fixes #103.

## Root cause

The path sampler selected a data index as if points were uniformly distributed across the X range, then required that point's actual timestamp-derived X coordinate to match the sampled pixel. For irregular time series, those two positions diverge, so valid intermediate values were dropped from the Skia path.

The sampler now walks the already-filtered, chronologically ordered data and applies the same density limit to each point's real X coordinate. This keeps path command counts bounded while representing irregular timestamps correctly.

## Verification

Using the repository Node.js version (`22.20.0`):

- focused regression observed RED before the fix: expected 3 cubic commands, received 2
- `yarn test --runInBand` — 2 suites, 4 tests passed
- `yarn typecheck`
- `yarn lint` — 0 errors; one pre-existing `no-shadow` warning in `src/AnimatedLineGraph.tsx`
- `yarn prepare`
- `CI=1 yarn workspace react-native-graph-example expo export --platform web --output-dir /tmp/graph-103-web-dist`
- `git diff --check`

## Scope

No public API or dependency changes. Static and animated graphs continue to create paths only when their input/layout changes, not per animation frame.
