### PR TITLE
docs: make usage example self-contained

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,15 @@ yarn add <b>react-native-graph</b>
 ## Usage
 
 ```tsx
-import { LineGraph } from 'react-native-graph';
+import { LineGraph, type GraphPoint } from 'react-native-graph';
+
+const priceHistory: GraphPoint[] = [
+  { date: new Date('2026-08-27T00:00:00Z'), value: 3.44 },
+  { date: new Date('2026-08-28T00:00:00Z'), value: 3.51 },
+  { date: new Date('2026-08-29T00:00:00Z'), value: 3.49 },
+];
 
 function App() {
-  const priceHistory = usePriceHistory('ethereum');
-
   return (
     <LineGraph
       style={{ height: 200 }}
@@ -57,6 +61,8 @@ function App() {
   );
 }
 ```
+
+`react-native-graph` does not fetch data or provide a `usePriceHistory` hook. Create the `GraphPoint[]` from your own API, state, or local data. Each point uses a `Date` for its horizontal position and a `number` for its vertical value; keep the points ordered from oldest to newest. Categorical string values are not supported on the x-axis.
 
 ## Configuration
 


### PR DESCRIPTION
## Summary

- replace the undefined `usePriceHistory()` call with a complete `GraphPoint[]` example
- import the public `GraphPoint` type so the supported data shape is visible immediately
- clarify that consumers provide their own data and that the x-axis is date-based

Fixes #109.

## Verification

Using the repository Node.js version (`22.20.0`):

- `yarn prettier --check README.md`
- `yarn test --runInBand` — 2 suites, 3 tests passed
- `yarn typecheck`
- `yarn lint` — 0 errors; one pre-existing `no-shadow` warning in `src/AnimatedLineGraph.tsx`
- `yarn prepare`
- `CI=1 yarn workspace react-native-graph-example expo export --platform web --output-dir /tmp/graph-109-web-dist`
- `git diff --check`

This is documentation-only; no runtime or public API behavior changes.
